### PR TITLE
Adds a mechanism to proxy around internal services.

### DIFF
--- a/beast-ingress.yaml
+++ b/beast-ingress.yaml
@@ -1,0 +1,33 @@
+# Allow domain names across subnets to propagate more easily.
+# Lets the hostname monitor pick up hosts that aren't managed by services in
+#   the cluster itself, while also getting SSL for free.
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${MACHINE_NAME}
+  namespace: domains
+spec:
+  type: ExternalName
+  externalName: ${MACHINE_IP}
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ${MACHINE_NAME}-ingress
+  namespace: domains
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/backend-protocol: "https"
+spec:
+  tls:
+    - hosts:
+        - ${MACHINE_NAME}.internal.aleemhaji.com
+      secretName: internal-certificate-files
+  rules:
+    - host: ${MACHINE_NAME}.internal.aleemhaji.com
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: ${MACHINE_NAME}
+              servicePort: 443

--- a/hope.yaml
+++ b/hope.yaml
@@ -400,6 +400,25 @@ resources:
     parameters:
       - *pihole_ingress_controller_ip
     tags: [apps, pihole]
+  - name: domain-namespace
+    inline: |
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: domains
+    tags: [domains]
+  - name: beast1-domain
+    file: beast-ingress.yaml
+    parameters:
+      - MACHINE_NAME=beast1
+      - MACHINE_IP=192.168.10.40
+    tags: [domains]
+  - name: beast2-domain
+    file: beast-ingress.yaml
+    parameters:
+      - MACHINE_NAME=beast2
+      - MACHINE_IP=192.168.10.41
+    tags: [domains]
   # region: Docker Image Caching
   # At this point, the registry has been pushed, and all the appropriate
   #   ingress configurations should be set to allow for images to be cached.
@@ -1123,6 +1142,12 @@ resources:
     parameters:
       - KUBERNETES_NAMESPACE=default
       - INCLUDE_EXTERNAL_CERTS=true
+    tags: [crons, certbot]
+  - name: certbot-update-domains
+    file: certbot/certbot-generic-cron.yaml
+    parameters:
+      - KUBERNETES_NAMESPACE=domains
+      - INCLUDE_EXTERNAL_CERTS=false
     tags: [crons, certbot]
   - name: certbot-cron
     file: certbot/certbot.yaml


### PR DESCRIPTION
Creates a simple service + ingress combo that can be applied to get free network-wide DNS for any internal IP that can't properly set up a hostname. 

Basically lets me take any endpoint, even those not in the Kubernetes cluster, and get SSL for free on top of them.

Could be partially solved by adding entries to the pihole `lan.list`, but this comes with getting SSL out of it too.

Seems to work well enough, even if it isn't the greatest thing ever.