### PR TITLE
Adds in the oldest node tagger

### DIFF
--- a/devbox.yaml
+++ b/devbox.yaml
@@ -2,11 +2,6 @@
 #   for experimentation.
 # Lives in its own namespace to keep itself a little further away from all
 #   other services.
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: dev
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/hope.yaml
+++ b/hope.yaml
@@ -373,6 +373,13 @@ resources:
       - DOCKER_REGISTRY_HOSTNAME
       - DOCKER_CONFIG_JSON_FILE_CONTENTS_BASE64
     tags: [apps, registry]
+  - name: cluster-registry-secrets-dev
+    file: registry/registry-secrets.yaml
+    parameters:
+      - NAMESPACE=dev
+      - DOCKER_REGISTRY_HOSTNAME
+      - DOCKER_CONFIG_JSON_FILE_CONTENTS_BASE64
+    tags: [apps, registry]
   - name: cluster-registry-secrets-monitoring
     file: registry/registry-secrets.yaml
     parameters:
@@ -1180,6 +1187,18 @@ resources:
     fileParameters:
       - JOBS_SHELL_MONITOR_SCRIPT=shell-monitor/delete-manual-jobs-monitor.sh
     tags: [shell-monitor]
+  - name: dev-namespace
+    inline: |
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: dev
+    tags: [rotate-node]
+  - name: rotate-node-tagger
+    file: node-rotator/rotate-node-tagger.yaml
+    fileParameters:
+      - ROTATE_NODE_TAGGER_SCRIPT=node-rotator/rotate-node-tagger.sh
+    tags: [rotate-node]
 jobs:
   - name: mysql-restore
     file: mysql/tasks/mysql-restore.yaml

--- a/node-rotator/rotate-node-tagger.sh
+++ b/node-rotator/rotate-node-tagger.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Label nodes with a value representing whether or not they're the oldest node
+#   running in the cluster.
+#
+set -eufo pipefail
+
+LABEL_NAME="aleemhaji.com/oldest"
+NODE_TEMPLATE='{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}} {{index .metadata.labels "node-role.kubernetes.io/master"}}
+{{end}}'
+
+label_node() {
+	if [ $# -ne 2 ]; then
+		echo >&2 "usage: label_node <node> <value>"
+		return 1
+	fi
+
+	node="$1"
+	label_value="$2"
+
+	if current_value="$(kubectl label node "$node" --list | grep "^$LABEL_NAME=" | sed "s?$LABEL_NAME=??")"; then
+		if [ "$current_value" != "$label_value" ]; then
+			kubectl label node "$node" --overwrite "$LABEL_NAME=$label_value"
+		else
+			echo >&2 "Skipping labeling $node $LABEL_NAME=$label_value becasue it's already set."
+		fi
+	else
+		kubectl label node "$node" "$LABEL_NAME=$label_value"
+	fi
+}
+
+readarray -t nodes < <(\
+	kubectl get nodes -o template="$NODE_TEMPLATE" | \
+	awk '{if (NF != 2) print}' | sort -k2 | awk '{print $1}')
+
+node="${nodes[0]}"
+label_node "$node" "true"
+
+nodes=("${nodes[@]:1}")
+for node in "${nodes[@]}"; do
+	label_node "$node" "false"
+done

--- a/node-rotator/rotate-node-tagger.yaml
+++ b/node-rotator/rotate-node-tagger.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rotate-node-tagger
+  namespace: dev
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rotate-node-tagger
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["patch", "get", "list"]
+apiVersion: rbac.authorization.k8s.io/v1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rotate-node-tagger
+subjects:
+  - kind: ServiceAccount
+    name: rotate-node-tagger
+    namespace: dev
+roleRef:
+  kind: ClusterRole
+  name: rotate-node-tagger
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: rotate-node-tagger-script
+  namespace: dev
+  labels:
+    app: rotate-node-tagger
+binaryData:
+  script.sh: ${ROTATE_NODE_TAGGER_SCRIPT}
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: rotate-node-tagger
+  namespace: dev
+spec:
+  schedule: "0 * * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: rotate-node-tagger
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: rotate-node-tagger
+          imagePullSecrets:
+            - name: registry.internal.aleemhaji.com
+          containers:
+            - name: rotate-node
+              image: registry.internal.aleemhaji.com/kubectl:1.21.0
+              command: 
+                - /scripts/script.sh
+              volumeMounts:
+                - name: rotate-node-tagger-scripts
+                  mountPath: /scripts
+          volumes:
+            - name: rotate-node-tagger-scripts
+              configMap:
+                name: rotate-node-tagger-script
+                defaultMode: 0755


### PR DESCRIPTION
Rips out the cron that tags nodes from #44 so that it's out of sight, out of mind.

Runs a job once an hour to tag nodes with a label indicating whether or not that node is the oldest in the cluster.

To be used along with a job that rotates nodes. The tag is used with node affinities to prevent the scheduler from putting the "delete and recreate the oldest node" job from running on the node to be removed.