### PR TITLE
Allows channels to be set by individual shell monitors

### DIFF
--- a/bookstack/bookstack-notifier.yaml
+++ b/bookstack/bookstack-notifier.yaml
@@ -54,6 +54,8 @@ spec:
               value: /scripts/monitor/script.sh
             - name: UPDATE_INTERVAL
               value: "3600"
+            - name: SLACK_BOT_ALERTING_CHANNEL
+              value: ${SLACK_BOT_ALERTING_CHANNEL}
             - name: TOKEN_ID
               valueFrom:
                 secretKeyRef:

--- a/hope.yaml
+++ b/hope.yaml
@@ -665,6 +665,8 @@ resources:
     tags: [crons, image-monitor, stateless]
   - name: image-monitor
     file: image-monitor/image-monitor.yaml
+    parameters:
+      - SLACK_BOT_ALERTING_CHANNEL
     tags: [crons, image-monitor, stateless]
   - name: browser
     file: browser/browser.yaml
@@ -1095,6 +1097,8 @@ resources:
     tags: [apps, bookstack]
   - name: bookstack-notifier
     file: bookstack/bookstack-notifier.yaml
+    parameters:
+      - SLACK_BOT_ALERTING_CHANNEL
     fileParameters:
       - BOOKSTACK_NOTIFIER_SCRIPT=bookstack/bookstack-notifier.sh
     tags: [apps, bookstack]
@@ -1229,12 +1233,13 @@ resources:
     file: shell-monitor/shell-monitor-base.yaml
     parameters:
       - SHELL_MONITOR_NAMESPACE=default
-      - SLACK_BOT_ALERTING_CHANNEL
     fileParameters:
       - SHELL_MONITOR_SCRIPT=shell-monitor/shell-monitor-script.sh
     tags: [shell-monitor]
   - name: events-shell-monitor
     file: shell-monitor/events-shell-monitor.yaml
+    parameters:
+      - SLACK_BOT_ALERTING_CHANNEL
     fileParameters:
       - EVENTS_SHELL_MONITOR_SCRIPT=shell-monitor/events-shell-monitor.sh
     tags: [shell-monitor]
@@ -1242,6 +1247,7 @@ resources:
     file: shell-monitor/delete-manual-jobs-monitor.yaml
     parameters:
       - KUBE_NAMESPACE=default
+      - SLACK_BOT_ALERTING_CHANNEL
     fileParameters:
       - JOBS_SHELL_MONITOR_SCRIPT=shell-monitor/delete-manual-jobs-monitor.sh
     tags: [shell-monitor]

--- a/image-monitor/image-monitor.yaml
+++ b/image-monitor/image-monitor.yaml
@@ -47,6 +47,8 @@ spec:
               value: /scripts/monitor/image-monitor.sh
             - name: UPDATE_INTERVAL
               value: "28800"
+            - name: SLACK_BOT_ALERTING_CHANNEL
+              value: ${SLACK_BOT_ALERTING_CHANNEL}
           volumeMounts:
             - name: image-monitor-script
               mountPath: /scripts/monitor

--- a/shell-monitor/delete-manual-jobs-monitor.yaml
+++ b/shell-monitor/delete-manual-jobs-monitor.yaml
@@ -87,6 +87,8 @@ spec:
               value: /scripts/monitor/script.sh
             - name: UPDATE_INTERVAL
               value: "3600"
+            - name: SLACK_BOT_ALERTING_CHANNEL
+              value: ${SLACK_BOT_ALERTING_CHANNEL}
           volumeMounts:
             - name: shell-monitor-base-scripts
               mountPath: /scripts/base

--- a/shell-monitor/events-shell-monitor.yaml
+++ b/shell-monitor/events-shell-monitor.yaml
@@ -81,6 +81,8 @@ spec:
               value: /scripts/monitor/script.sh
             - name: UPDATE_INTERVAL
               value: "3600"
+            - name: SLACK_BOT_ALERTING_CHANNEL
+              value: ${SLACK_BOT_ALERTING_CHANNEL}
           volumeMounts:
             - name: shell-monitor-base-scripts
               mountPath: /scripts/base


### PR DESCRIPTION
The original implementation replaced the channel in the shell script that was written out to config. This version leaves that value as an unfilled env var, and leaves it to the individual scripts to add their own channels. 

